### PR TITLE
feat(frontend): Share button and export modal UI

### DIFF
--- a/docs/epics/EPIC-data-export-sharing.md
+++ b/docs/epics/EPIC-data-export-sharing.md
@@ -1,7 +1,7 @@
 # Data Export & Social Sharing
 
 ## Status
-🟢 Backend Complete
+🟢 Complete
 
 ## Acceptance Criteria
 - [x] Shareable image generation (square, story, wide, compact)
@@ -10,6 +10,10 @@
 - [x] CSV data export
 - [x] Open Graph metadata for link previews
 - [x] Share text generation for social platforms
+- [x] Share button/modal UI
+- [x] Copy-to-clipboard functionality
+- [x] Direct social sharing links (Twitter, Facebook, WhatsApp, LinkedIn)
+- [x] Native Web Share API on mobile
 
 ## Technical Approach
 
@@ -31,11 +35,23 @@ Export:
 - `GET /api/export/og` - Open Graph metadata for link previews
 - `GET /api/export/share-text` - Share text for social platforms
 
-### Frontend (Pending)
-- Share button/modal UI
-- Image preview before sharing
-- Copy-to-clipboard functionality
-- Direct social sharing links
+### Frontend (Complete)
+
+**Share Module** (`frontend/js/share.js`)
+- Download functions for image, PDF, JSON, CSV exports
+- Social sharing functions (Twitter, Facebook, WhatsApp, LinkedIn)
+- Copy link to clipboard functionality
+- Native Web Share API support on mobile
+- Toast notifications for user feedback
+
+**UI Components**
+- Header share button with icon
+- Share modal with three sections:
+  - Social sharing buttons
+  - Image export (Square/Story/Wide formats)
+  - Data export (PDF/JSON/CSV)
+- Accessible with keyboard navigation and ARIA labels
+- Responsive design (icon-only on mobile, with text on desktop)
 
 ## Configuration
 

--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -229,6 +229,56 @@ body {
   transform: scale(0.95);
 }
 
+/* Header Share Button - With text label */
+.header-share-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--spacing-xs);
+  height: var(--touch-target);
+  padding: 0 var(--spacing-md);
+  border: 1px solid var(--bg-hover);
+  border-radius: var(--radius-md);
+  background: var(--bg-card);
+  color: var(--text-primary);
+  font-size: 0.85rem;
+  font-family: inherit;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background var(--transition-fast), border-color var(--transition-fast), transform var(--transition-fast);
+  -webkit-tap-highlight-color: transparent;
+}
+
+.header-share-btn:hover {
+  background: var(--bg-hover);
+  border-color: var(--bar-fill);
+}
+
+.header-share-btn:focus {
+  outline: 2px solid var(--bar-fill);
+  outline-offset: 2px;
+}
+
+.header-share-btn:active {
+  transform: scale(0.95);
+}
+
+.header-share-btn .share-icon {
+  width: 18px;
+  height: 18px;
+  flex-shrink: 0;
+}
+
+.header-share-btn .share-btn-text {
+  display: none;
+}
+
+@media (min-width: 480px) {
+  .header-share-btn .share-btn-text {
+    display: inline;
+  }
+}
+
 /* Indices Bar - Mobile first */
 .indices-bar {
   display: flex;
@@ -1107,6 +1157,12 @@ body {
 
 .export-icon {
   font-size: 1.5rem;
+}
+
+.export-btn small {
+  font-size: 0.7rem;
+  color: var(--text-muted);
+  font-weight: 400;
 }
 
 /* Share Toast */

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -18,9 +18,21 @@
     <!-- Header -->
     <header class="header">
       <h1 class="header-title">WHAT'S HAPPENING</h1>
-      <div class="live-indicator">
-        <span class="live-dot"></span>
-        <span class="live-text">Loading...</span>
+      <div class="header-actions">
+        <button id="share-btn" class="header-share-btn" aria-label="Share" title="Share & Export">
+          <svg class="share-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <circle cx="18" cy="5" r="3"></circle>
+            <circle cx="6" cy="12" r="3"></circle>
+            <circle cx="18" cy="19" r="3"></circle>
+            <line x1="8.59" y1="13.51" x2="15.42" y2="17.49"></line>
+            <line x1="15.41" y1="6.51" x2="8.59" y2="10.49"></line>
+          </svg>
+          <span class="share-btn-text">Share</span>
+        </button>
+        <div class="live-indicator">
+          <span class="live-dot"></span>
+          <span class="live-text">Loading...</span>
+        </div>
       </div>
     </header>
 
@@ -109,6 +121,115 @@
     <div class="error-banner hidden" id="error-banner" role="alert" aria-live="assertive">
       <span class="error-text">Connection error. Showing cached data.</span>
       <button class="error-dismiss" onclick="dismissError()" aria-label="Dismiss error">×</button>
+    </div>
+  </div>
+
+  <!-- Share Modal -->
+  <div id="share-modal" class="share-modal hidden" role="dialog" aria-modal="true" aria-labelledby="share-modal-title">
+    <div class="share-modal-content">
+      <div class="share-modal-header">
+        <h2 id="share-modal-title">Share & Export</h2>
+        <button id="share-modal-close" class="share-modal-close" aria-label="Close modal">&times;</button>
+      </div>
+      <div class="share-modal-body">
+        <!-- Social Sharing Section -->
+        <div class="share-section">
+          <h3 class="share-section-title">Share on Social</h3>
+          <div class="share-buttons">
+            <button id="share-twitter" class="share-btn share-btn-twitter" aria-label="Share on Twitter">
+              <svg class="share-icon" width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
+                <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/>
+              </svg>
+              <span>Twitter/X</span>
+            </button>
+            <button id="share-facebook" class="share-btn share-btn-facebook" aria-label="Share on Facebook">
+              <svg class="share-icon" width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
+                <path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/>
+              </svg>
+              <span>Facebook</span>
+            </button>
+            <button id="share-whatsapp" class="share-btn share-btn-whatsapp" aria-label="Share on WhatsApp">
+              <svg class="share-icon" width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
+                <path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347m-5.421 7.403h-.004a9.87 9.87 0 01-5.031-1.378l-.361-.214-3.741.982.998-3.648-.235-.374a9.86 9.86 0 01-1.51-5.26c.001-5.45 4.436-9.884 9.888-9.884 2.64 0 5.122 1.03 6.988 2.898a9.825 9.825 0 012.893 6.994c-.003 5.45-4.437 9.884-9.885 9.884m8.413-18.297A11.815 11.815 0 0012.05 0C5.495 0 .16 5.335.157 11.892c0 2.096.547 4.142 1.588 5.945L.057 24l6.305-1.654a11.882 11.882 0 005.683 1.448h.005c6.554 0 11.89-5.335 11.893-11.893a11.821 11.821 0 00-3.48-8.413z"/>
+              </svg>
+              <span>WhatsApp</span>
+            </button>
+            <button id="share-linkedin" class="share-btn share-btn-linkedin" aria-label="Share on LinkedIn">
+              <svg class="share-icon" width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
+                <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z"/>
+              </svg>
+              <span>LinkedIn</span>
+            </button>
+            <button id="share-copy-link" class="share-btn share-btn-link" aria-label="Copy link">
+              <svg class="share-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"></path>
+                <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"></path>
+              </svg>
+              <span>Copy Link</span>
+            </button>
+          </div>
+        </div>
+
+        <!-- Export Images Section -->
+        <div class="share-section">
+          <h3 class="share-section-title">Download Image</h3>
+          <div class="share-buttons export-buttons">
+            <button id="export-image-square" class="share-btn export-btn" aria-label="Download square image">
+              <svg class="share-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <rect x="3" y="3" width="18" height="18" rx="2" ry="2"></rect>
+              </svg>
+              <span>Square</span>
+              <small>1080×1080</small>
+            </button>
+            <button id="export-image-story" class="share-btn export-btn" aria-label="Download story image">
+              <svg class="share-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <rect x="6" y="2" width="12" height="20" rx="2" ry="2"></rect>
+              </svg>
+              <span>Story</span>
+              <small>1080×1920</small>
+            </button>
+            <button id="export-image-wide" class="share-btn export-btn" aria-label="Download wide image">
+              <svg class="share-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <rect x="2" y="6" width="20" height="12" rx="2" ry="2"></rect>
+              </svg>
+              <span>Wide</span>
+              <small>1200×630</small>
+            </button>
+          </div>
+        </div>
+
+        <!-- Export Data Section -->
+        <div class="share-section">
+          <h3 class="share-section-title">Export Data</h3>
+          <div class="share-buttons export-buttons">
+            <button id="export-pdf" class="share-btn export-btn" aria-label="Download PDF report">
+              <svg class="share-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path>
+                <polyline points="14 2 14 8 20 8"></polyline>
+                <line x1="16" y1="13" x2="8" y2="13"></line>
+                <line x1="16" y1="17" x2="8" y2="17"></line>
+                <polyline points="10 9 9 9 8 9"></polyline>
+              </svg>
+              <span>PDF Report</span>
+            </button>
+            <button id="export-json" class="share-btn export-btn" aria-label="Download JSON data">
+              <svg class="share-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <polyline points="16 18 22 12 16 6"></polyline>
+                <polyline points="8 6 2 12 8 18"></polyline>
+              </svg>
+              <span>JSON</span>
+            </button>
+            <button id="export-csv" class="share-btn export-btn" aria-label="Download CSV data">
+              <svg class="share-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path>
+                <polyline points="7 10 12 15 17 10"></polyline>
+                <line x1="12" y1="15" x2="12" y2="3"></line>
+              </svg>
+              <span>CSV</span>
+            </button>
+          </div>
+        </div>
+      </div>
     </div>
   </div>
 


### PR DESCRIPTION
## Summary
Complete frontend implementation for PR #62 - Data Export & Social Sharing.

## Changes
- **Header share button** with responsive design (icon-only on mobile, with text on desktop)
- **Share modal** with three organized sections:
  - Social sharing: Twitter/X, Facebook, WhatsApp, LinkedIn, Copy Link
  - Image export: Square (1080×1080), Story (1080×1920), Wide (1200×630)
  - Data export: PDF Report, JSON, CSV

## Features
- Native Web Share API support on mobile devices
- Toast notifications for user feedback
- Accessible with ARIA labels and keyboard navigation
- Dark/light theme compatible

## Files Changed
- `frontend/index.html` - Added share button to header and share modal markup
- `frontend/css/styles.css` - Added header-share-btn and export-btn small styles
- `docs/epics/EPIC-data-export-sharing.md` - Updated status to Complete

## Testing
- [ ] Share button opens modal on desktop
- [ ] Share button triggers native share on mobile (if supported)
- [ ] Social sharing buttons open correct URLs
- [ ] Export buttons download files with correct filenames
- [ ] Modal closes on X, overlay click, or Escape key

Closes frontend tasks for epic #62.