### PR TITLE
[EPIC-089] Frontend Deployment Fix

### DIFF
--- a/frontend/js/config.js
+++ b/frontend/js/config.js
@@ -17,6 +17,21 @@ function getApiUrl() {
     return 'https://whatshappening-api-89qq.onrender.com';
   }
 
+  // Render.com static site deployment
+  if (hostname.includes('onrender.com')) {
+    return 'https://whatshappening-api-89qq.onrender.com';
+  }
+
+  // Vercel deployment
+  if (hostname.includes('vercel.app')) {
+    return 'https://whatshappening-api-89qq.onrender.com';
+  }
+
+  // Netlify deployment
+  if (hostname.includes('netlify.app')) {
+    return 'https://whatshappening-api-89qq.onrender.com';
+  }
+
   // Production - adjust domain as needed
   if (window.location.protocol === 'https:') {
     return window.API_URL || `${window.location.protocol}//${hostname.replace('www.', 'api.')}`;

--- a/frontend/netlify.toml
+++ b/frontend/netlify.toml
@@ -1,0 +1,26 @@
+# Netlify deployment configuration
+[build]
+  publish = "."
+  command = "echo 'Static site - no build required'"
+
+# SPA routing - redirect all paths to index.html
+[[redirects]]
+  from = "/*"
+  to = "/index.html"
+  status = 200
+
+# Cache headers for static assets
+[[headers]]
+  for = "/css/*"
+  [headers.values]
+    Cache-Control = "public, max-age=31536000, immutable"
+
+[[headers]]
+  for = "/js/*"
+  [headers.values]
+    Cache-Control = "public, max-age=31536000, immutable"
+
+[[headers]]
+  for = "/*"
+  [headers.values]
+    Cache-Control = "public, max-age=300"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "whatshappening-frontend",
+  "version": "1.0.0",
+  "description": "WhatsHappening frontend - static PWA",
+  "type": "module",
+  "scripts": {
+    "start": "npx serve -s . -l 3000",
+    "preview": "npx serve -s . -l 3000",
+    "test": "echo \"No tests configured\" && exit 0"
+  },
+  "keywords": [
+    "pwa",
+    "dashboard",
+    "predictions"
+  ],
+  "author": "WhatsHappening Team",
+  "license": "MIT",
+  "engines": {
+    "node": ">=18.0.0"
+  }
+}

--- a/render.yaml
+++ b/render.yaml
@@ -22,6 +22,29 @@ services:
       - key: NPM_CONFIG_OPTIONAL
         value: "true"
 
+  - type: web
+    name: whatshappening-frontend
+    runtime: static
+    region: oregon
+    plan: free
+    rootDir: frontend
+    buildCommand: echo "Static site - no build required"
+    staticPublishPath: .
+    headers:
+      - path: /*
+        name: Cache-Control
+        value: public, max-age=300
+      - path: /css/*
+        name: Cache-Control
+        value: public, max-age=31536000, immutable
+      - path: /js/*
+        name: Cache-Control
+        value: public, max-age=31536000, immutable
+    routes:
+      - type: rewrite
+        source: /*
+        destination: /index.html
+
 databases:
   - name: whatshappening-db
     databaseName: whatshappening


### PR DESCRIPTION
## Summary
Fixes frontend deployment configuration to enable static site deployment on multiple platforms.

## Changes
- **render.yaml**: Added frontend static site service with proper cache headers and SPA routing
- **config.js**: Updated API URL detection to support Render, Vercel, and Netlify deployments
- **package.json**: Added for local development server with `npm start`
- **netlify.toml**: Added Netlify deployment configuration as alternative option
- **vercel.json**: Already existed with proper SPA routing

## Deployment Options
The frontend can now be deployed to:
1. **Render** - Using the Blueprint (render.yaml)
2. **Vercel** - Just connect the repo, set root to `frontend/`
3. **Netlify** - Just connect the repo, set root to `frontend/`

## Testing
- Static files load correctly
- SPA routing configured for all platforms
- Cache headers optimized for performance

Closes #89