### PR TITLE
feat(cd): Add Railway backend deployment workflow

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -1,0 +1,100 @@
+name: Deploy Backend to Railway
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'backend/**'
+      - '.github/workflows/deploy-backend.yml'
+  workflow_dispatch:
+
+# Prevent concurrent deployments
+concurrency:
+  group: deploy-backend-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    name: Deploy to Railway
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    
+    # Only deploy if tests pass (requires ci.yml to run first)
+    # For direct pushes to main, we trust the branch protection rules
+    
+    steps:
+      - name: Check Railway configuration
+        id: check-config
+        env:
+          RAILWAY_TOKEN_SET: ${{ secrets.RAILWAY_TOKEN != '' }}
+        run: |
+          if [ "$RAILWAY_TOKEN_SET" = "true" ]; then
+            echo "configured=true" >> $GITHUB_OUTPUT
+          else
+            echo "configured=false" >> $GITHUB_OUTPUT
+            echo "⚠ RAILWAY_TOKEN not set - skipping deploy"
+            echo ""
+            echo "To configure Railway deployment:"
+            echo "1. Go to Railway dashboard → Project Settings → Tokens"
+            echo "2. Create a new token"
+            echo "3. Add RAILWAY_TOKEN as a repository secret in GitHub"
+          fi
+
+      - name: Checkout code
+        if: steps.check-config.outputs.configured == 'true'
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+      - name: Setup Node.js
+        if: steps.check-config.outputs.configured == 'true'
+        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
+        with:
+          node-version: '20'
+
+      - name: Install Railway CLI
+        if: steps.check-config.outputs.configured == 'true'
+        run: npm install -g @railway/cli
+
+      - name: Deploy to Railway
+        if: steps.check-config.outputs.configured == 'true'
+        env:
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+        working-directory: backend
+        run: |
+          echo "Deploying backend to Railway..."
+          railway up --detach
+          echo "✓ Railway deployment triggered"
+
+      - name: Verify deployment
+        if: steps.check-config.outputs.configured == 'true'
+        env:
+          BACKEND_URL: ${{ vars.BACKEND_URL }}
+        run: |
+          if [ -z "$BACKEND_URL" ]; then
+            echo "⚠ BACKEND_URL not set - skipping health check"
+            echo "Set BACKEND_URL in repository variables for post-deploy verification"
+            exit 0
+          fi
+          
+          echo "Waiting for deployment to propagate..."
+          sleep 45
+          
+          # Retry up to 5 times with backoff
+          for i in 1 2 3 4 5; do
+            response=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 "$BACKEND_URL/health" 2>/dev/null || echo "000")
+            if [ "$response" = "200" ]; then
+              echo "✓ Health check passed (attempt $i)"
+              
+              # Verify response content
+              health_response=$(curl -s --max-time 10 "$BACKEND_URL/health" 2>/dev/null)
+              echo "Health response: $health_response"
+              exit 0
+            fi
+            echo "Attempt $i: HTTP $response, retrying in $((i * 15))s..."
+            sleep $((i * 15))
+          done
+          
+          echo "❌ Health check failed after 5 attempts"
+          exit 1


### PR DESCRIPTION
## Summary
Add dedicated Railway deployment workflow for the backend service.

## Changes
- Created `.github/workflows/deploy-backend.yml` for Railway deployments
- Triggers on push to main when `backend/**` files change
- Uses Railway CLI (`railway up`) for deployments
- Includes health check verification after deployment
- Gracefully skips deployment if `RAILWAY_TOKEN` not configured

## Configuration Required
To enable Railway deployments:
1. Go to Railway dashboard → Project Settings → Tokens
2. Create a new project token
3. Add `RAILWAY_TOKEN` as a repository secret in GitHub
4. (Optional) Set `BACKEND_URL` in repository variables for health checks

## Acceptance Criteria from #113
- [x] Backend auto-deploys on main push (`backend/**` changes trigger deploy)
- [x] Health check confirms deployment (retries up to 5 times with backoff)

## Notes
- This is separate from the Render deployment in ci.yml
- Only one deployment target should be active at a time
- Consider removing the Render deploy job from ci.yml after Railway is configured

Closes #113