### PR TITLE
feat: Progressive Web App (PWA) Capabilities

### DIFF
--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -2275,6 +2275,17 @@ button:focus-visible,
   transform: scale(1.05);
 }
 
+/* Offline Banner */
+.offline-banner {
+  background: var(--warning-color, #e2b340);
+  color: #000;
+  text-align: center;
+  padding: 8px 16px;
+  font-size: 0.875rem;
+  font-weight: 600;
+  z-index: 1000;
+}
+
 /* Responsive PWA Banner */
 @media (max-width: 480px) {
   .pwa-install-banner {

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -7,6 +7,9 @@
   <meta name="theme-color" content="#0a0a0f">
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+  <link rel="manifest" href="/manifest.json">
+  <link rel="apple-touch-icon" href="/icons/icon-152.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="/icons/icon-96.png">
   <title>What's Happening</title>
   <!-- Google Analytics -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-2EECHBPF6C"></script>
@@ -75,6 +78,10 @@
   <a href="#main-content" class="skip-link">Skip to main content</a>
   
   <div id="app">
+    <!-- Offline indicator -->
+    <div id="offline-banner" class="offline-banner" role="alert" aria-live="polite" hidden>
+      ⚠️ You're offline — showing cached data
+    </div>
     <!-- Header -->
     <header class="header">
       <h1 class="header-title">WHAT'S HAPPENING</h1>

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -18,6 +18,7 @@ import consentBanner from './components/consent-banner.js';
 import { init as initPerformance, getMetrics } from './performance.js';
 import ErrorTracker from './error-tracking.js';
 import { initShare } from './share.js';
+import './pwa.js';
 import { initThemeToggle } from './components/themeToggle.js';
 
 // Lazy-loaded modules (non-critical path)

--- a/frontend/js/pwa.js
+++ b/frontend/js/pwa.js
@@ -253,5 +253,28 @@ export async function clearCaches() {
   console.log('[PWA] Cache clear requested');
 }
 
+/**
+ * Initialize offline detection UI
+ */
+function initOfflineDetection() {
+  const banner = document.getElementById('offline-banner');
+  if (!banner) return;
+
+  function updateStatus() {
+    banner.hidden = navigator.onLine;
+  }
+
+  window.addEventListener('online', updateStatus);
+  window.addEventListener('offline', updateStatus);
+  updateStatus();
+}
+
 // Auto-initialize when module loads
 initPWA();
+
+// Initialize offline detection when DOM is ready
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', initOfflineDetection);
+} else {
+  initOfflineDetection();
+}


### PR DESCRIPTION
## Summary

Wires up the existing PWA infrastructure (service worker, manifest, icons) that was previously created but not connected to the app.

### Changes
- **Import pwa.js** in app.js to activate service worker registration, install prompts, and update notifications
- **Add manifest & icon links** to index.html (`<link rel="manifest">`, apple-touch-icon, favicon)
- **Add offline detection** — banner appears when user goes offline, hides when back online
- **Add offline banner CSS** — warning-colored bar at top of page

### What was already built (just needed wiring)
- `frontend/sw.js` — Service worker with cache-first for assets, network-first for API
- `frontend/manifest.json` — Web app manifest with all icon sizes
- `frontend/icons/` — Full icon set (72–512px + maskable)
- `frontend/js/pwa.js` — Install prompt, update notification, cache management
- `frontend/css/styles.css` — PWA banner and notification styles

Fixes #75