### PR TITLE
feat: Data Export & Social Sharing — OG metadata

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,6 +4,19 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
   <meta name="description" content="Data-driven prediction dashboard correlating cosmic and esoteric data with real-world measurable outcomes">
+  <!-- Open Graph -->
+  <meta property="og:title" content="What's Happening — Cosmic Prediction Dashboard">
+  <meta property="og:description" content="Data-driven predictions correlating cosmic and esoteric data with real-world outcomes">
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="https://whatshappening.app">
+  <meta property="og:image" content="https://whatshappening.app/api/export/image?format=wide">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <!-- Twitter Card -->
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="What's Happening — Cosmic Prediction Dashboard">
+  <meta name="twitter:description" content="Data-driven predictions correlating cosmic and esoteric data with real-world outcomes">
+  <meta name="twitter:image" content="https://whatshappening.app/api/export/image?format=wide">
   <meta name="theme-color" content="#0a0a0f">
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">


### PR DESCRIPTION
## Summary

The export/sharing infrastructure was already built (share modal, export endpoints, social buttons, Web Share API). This PR adds the missing Open Graph and Twitter Card metadata needed for link previews when sharing.

### Changes
- **Open Graph tags**: og:title, og:description, og:type, og:url, og:image (1200x630 wide format)
- **Twitter Card tags**: summary_large_image card with title, description, and image

### Already Implemented (in main)
- Share modal with Twitter, Facebook, WhatsApp, LinkedIn buttons
- Image/PDF/JSON/CSV export endpoints (`/api/export/*`)
- Web Share API integration for mobile
- Copy link functionality
- Share button in header

Fixes #78