### PR TITLE
fix: resolve bugs #8, #9, #10 — Hebrew date, Yahoo Finance, news feeds

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@google/generative-ai": "^0.21.0",
+        "@hebcal/core": "^6.0.8",
         "axios": "^1.6.5",
         "cheerio": "^1.0.0-rc.12",
         "cookie-parser": "^1.4.7",
@@ -96,6 +97,37 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@hebcal/core": {
+      "version": "6.0.8",
+      "resolved": "https://registry.npmjs.org/@hebcal/core/-/core-6.0.8.tgz",
+      "integrity": "sha512-UgH1OOD09dcvES5EgeF6VSYqWAIC2fq+EjNsCid9fl2RRlDhO931puRZp4AFCSZ6Mp6iO//XqZ7NfQ4ZUs3LFw==",
+      "license": "GPL-2.0",
+      "dependencies": {
+        "@hebcal/hdate": "^0.21.1",
+        "@hebcal/noaa": "^0.9.2",
+        "quick-lru": "^7.3.0",
+        "temporal-polyfill": "^0.3.0",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      }
+    },
+    "node_modules/@hebcal/hdate": {
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/@hebcal/hdate/-/hdate-0.21.1.tgz",
+      "integrity": "sha512-YeDYuo29OUmAug1B3Jnnkn/s6AZ28V0mCChsi8HdcZKlTVi8VrKQ2Iryo6CKW4d+NkdNuAmnOzOI/bH2DxYckA==",
+      "license": "GPL-2.0"
+    },
+    "node_modules/@hebcal/noaa": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/@hebcal/noaa/-/noaa-0.9.2.tgz",
+      "integrity": "sha512-pw6hixqxdgkhaxj/5aQgaBYevLUaerUvEIPNUSKYn2B77NOH4xZQF1A3YZlXel8MzGHyVbtB434uS4QAOMjZWQ==",
+      "license": "LGPL-2.1",
+      "dependencies": {
+        "temporal-polyfill": "^0.3.0"
       }
     },
     "node_modules/@jsdevtools/ono": {
@@ -1673,6 +1705,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/quick-lru": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-7.3.0.tgz",
+      "integrity": "sha512-k9lSsjl36EJdK7I06v7APZCbyGT2vMTsYSRX1Q2nbYmnkBqgUhRkAuzH08Ciotteu/PLJmIF2+tti7o3C/ts2g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -1972,6 +2016,21 @@
         "express": ">=4.0.0 || >=5.0.0-beta"
       }
     },
+    "node_modules/temporal-polyfill": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/temporal-polyfill/-/temporal-polyfill-0.3.0.tgz",
+      "integrity": "sha512-qNsTkX9K8hi+FHDfHmf22e/OGuXmfBm9RqNismxBrnSmZVJKegQ+HYYXT+R7Ha8F/YSm2Y34vmzD4cxMu2u95g==",
+      "license": "MIT",
+      "dependencies": {
+        "temporal-spec": "0.3.0"
+      }
+    },
+    "node_modules/temporal-spec": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/temporal-spec/-/temporal-spec-0.3.0.tgz",
+      "integrity": "sha512-n+noVpIqz4hYgFSMOSiINNOUOMFtV5cZQNCmmszA6GiVFVRt3G7AqVyhXjhCSmowvQn+NsGn+jMDMKJYHd3bSQ==",
+      "license": "ISC"
+    },
     "node_modules/tldts": {
       "version": "6.1.86",
       "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
@@ -2022,6 +2081,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/type-is": {
       "version": "1.6.18",

--- a/backend/package.json
+++ b/backend/package.json
@@ -19,6 +19,7 @@
   "license": "MIT",
   "dependencies": {
     "@google/generative-ai": "^0.21.0",
+    "@hebcal/core": "^6.0.8",
     "axios": "^1.6.5",
     "cheerio": "^1.0.0-rc.12",
     "cookie-parser": "^1.4.7",

--- a/backend/src/modules/gematria.js
+++ b/backend/src/modules/gematria.js
@@ -33,9 +33,13 @@ async function convertToHebrewDate(date) {
   try {
     const response = await fetchHebcalAPI(url);
 
+    // Normalize month names to match our HEBREW_MONTHS list
+    const MONTH_NAME_MAP = { "Sh'vat": 'Shevat', 'Tamuz': 'Tammuz' };
+    const month = MONTH_NAME_MAP[response.hm] || response.hm;
+
     return {
       day: response.hd,
-      month: response.hm,
+      month,
       year: response.hy,
       hebrew: response.hebrew,
     };
@@ -61,41 +65,32 @@ async function fetchHebcalAPI(url) {
 }
 
 /**
- * Fallback Hebrew date calculation (simplified approximation)
- * Note: This is a simplified calculation for MVP. For accurate conversion,
- * use the Hebcal API or a proper Hebrew calendar library.
+ * Fallback Hebrew date calculation using @hebcal/core (offline, no API needed).
+ * Replaces the broken naive mapping that used Gregorian day/month directly.
  *
  * @param {Date} date - JavaScript Date
- * @returns {Object} Hebrew date components
+ * @returns {Promise<Object>} Hebrew date components
  */
-function calculateHebrewDateFallback(date) {
-  // Hebrew calendar epoch: September 7, -3760 (Gregorian proleptic)
-  // This is a VERY simplified approximation for demonstration
-  // Real Hebrew calendar is lunisolar and requires complex calculations
+async function calculateHebrewDateFallback(date) {
+  const { HDate } = await import('@hebcal/core');
+  const hd = new HDate(date);
+  const hebrewDay = hd.getDate();
+  const hebrewMonthName = hd.getMonthName();
+  const hebrewYear = hd.getFullYear();
 
-  const HEBREW_EPOCH = new Date('1970-09-27'); // Approximation for epoch adjustment
-  const now = new Date(date);
+  // @hebcal/core uses slightly different transliterations (Sh'vat, Tamuz)
+  // Normalize to match our HEBREW_MONTHS list (Shevat, Tammuz)
+  const MONTH_NAME_MAP = { "Sh'vat": 'Shevat', 'Tamuz': 'Tammuz' };
+  const normalizedMonth = MONTH_NAME_MAP[hebrewMonthName] || hebrewMonthName;
+  const monthObj = HEBREW_MONTHS.find(m => m.name === normalizedMonth);
+  const monthHebrew = monthObj ? monthObj.hebrew : '';
 
-  // Simplified: Just use current date to return a sample Hebrew date
-  // In production, this should use proper Hebrew calendar conversion
-  const monthIndex = date.getMonth();
-  const monthMapping = [
-    'Tevet', 'Shevat', 'Adar', 'Nisan', 'Iyyar', 'Sivan',
-    'Tammuz', 'Av', 'Elul', 'Tishrei', 'Cheshvan', 'Kislev'
-  ];
-
-  const hebrewMonth = HEBREW_MONTHS.find(m => m.name === monthMapping[monthIndex]);
-  const hebrewYear = 5786; // Sample year - should be calculated
-  const hebrewDay = date.getDate();
-
-  // Format Hebrew date string (simplified)
-  const dayStr = String(hebrewDay);
-  const hebrew = `${dayStr} ${hebrewMonth.name} ${hebrewYear}`;
+  const hebrew = `${hebrewDay} ${normalizedMonth} ${hebrewYear}`;
 
   return {
     day: hebrewDay,
-    month: hebrewMonth.name,
-    monthHebrew: hebrewMonth.hebrew,
+    month: normalizedMonth,
+    monthHebrew,
     year: hebrewYear,
     hebrew,
   };

--- a/backend/src/modules/markets.js
+++ b/backend/src/modules/markets.js
@@ -17,7 +17,9 @@ async function getYahooFinance() {
   if (!yahooFinance) {
     try {
       const module = await import('yahoo-finance2');
-      yahooFinance = module.default;
+      const YahooFinance = module.default;
+      // v2.x default export is a class constructor, not a plain object
+      yahooFinance = typeof YahooFinance === 'function' ? new YahooFinance() : YahooFinance;
     } catch (error) {
       console.error('Failed to load yahoo-finance2:', error.message);
       return null;

--- a/backend/src/modules/news.js
+++ b/backend/src/modules/news.js
@@ -18,10 +18,12 @@ const cache = require('../utils/cache');
 const logger = require('../utils/logger');
 
 // RSS Feed URLs
+// Reuters and AP feeds are dead (404/403 as of 2025). Replaced with working alternatives.
 const RSS_FEEDS = {
-  Reuters: 'https://www.reutersagency.com/feed/',
-  AP: 'https://rsshub.app/apnews/topics/apf-topnews',
-  BBC: 'http://feeds.bbci.co.uk/news/world/rss.xml',
+  BBC: 'https://feeds.bbci.co.uk/news/world/rss.xml',
+  NYT: 'https://rss.nytimes.com/services/xml/rss/nyt/World.xml',
+  NPR: 'https://feeds.npr.org/1001/rss.xml',
+  AlJazeera: 'https://www.aljazeera.com/xml/rss/all.xml',
 };
 
 // Cache keys


### PR DESCRIPTION
## Summary

Fixes three backend bugs in one PR — all are data module fixes with no interdependencies.

### #8 — Gematria module returns incorrect Hebrew date
**Root cause:** Fallback Hebrew date calculation was completely broken — it used Gregorian `date.getDate()` as the Hebrew day, a naive month-index mapping, and a hardcoded year (5786).

**Fix:** Replace with `@hebcal/core` (offline, no API needed) for accurate lunisolar calendar conversion. Also normalize month name differences between Hebcal (`Sh'vat`, `Tamuz`) and our internal list (`Shevat`, `Tammuz`).

### #9 — Yahoo Finance API broken (`yf.quote is not a function`)
**Root cause:** `yahoo-finance2` v2.14 default ESM export is a **class constructor**, not an instance. The code did `yahooFinance = module.default` and then called `yf.quote()` on the class itself.

**Fix:** Instantiate with `new YahooFinance()` so `.quote()` is available on the instance.

### #10 — News feeds returning errors (403, 404)
**Root cause:** Reuters feed returns 404, AP via RSSHub returns 403. Both endpoints are dead.

**Fix:** Replace with working feeds — BBC (updated to HTTPS), NYT World, NPR, Al Jazeera. All verified returning 200 with valid RSS content.

## Testing
- `@hebcal/core` verified: Feb 4, 2026 → 17 Sh'vat 5786 (matches Hebcal API)
- `yf.quote` confirmed as function after instantiation
- All 4 RSS feeds verified: BBC (30), NYT (62), NPR (10), AlJazeera (25) items

Closes #8, closes #9, closes #10