### PR TITLE
[EPIC-005] Push Notifications for Pattern Alerts (#76)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -10,3 +10,9 @@ DATABASE_URL=postgres://username:password@localhost:5432/whatshappening
 # Google Gemini API key for news analysis
 GEMINI_API_KEY=your-gemini-api-key-here
 
+# Push Notifications (VAPID)
+# Generate with: npx web-push generate-vapid-keys
+VAPID_PUBLIC_KEY=
+VAPID_PRIVATE_KEY=
+VAPID_SUBJECT=mailto:alerts@whatshappening.app
+

--- a/backend/migrations/007_push_subscriptions.sql
+++ b/backend/migrations/007_push_subscriptions.sql
@@ -1,0 +1,32 @@
+-- Push notification subscriptions for EPIC-005
+
+CREATE TABLE IF NOT EXISTS push_subscriptions (
+  id SERIAL PRIMARY KEY,
+  endpoint TEXT UNIQUE NOT NULL,
+  keys_p256dh TEXT NOT NULL,
+  keys_auth TEXT NOT NULL,
+  preferences JSONB DEFAULT '{
+    "pattern_alerts": true,
+    "prediction_shifts": true,
+    "daily_summary": false,
+    "quiet_hours": {"start": 23, "end": 7}
+  }',
+  created_at TIMESTAMP DEFAULT NOW(),
+  last_used TIMESTAMP,
+  user_agent TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_push_subscriptions_endpoint ON push_subscriptions(endpoint);
+
+-- Track notification sends for rate limiting
+CREATE TABLE IF NOT EXISTS notification_log (
+  id SERIAL PRIMARY KEY,
+  subscription_id INTEGER REFERENCES push_subscriptions(id) ON DELETE CASCADE,
+  notification_type TEXT NOT NULL,
+  payload JSONB,
+  sent_at TIMESTAMP DEFAULT NOW(),
+  success BOOLEAN DEFAULT true,
+  error_message TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_notification_log_sub_date ON notification_log(subscription_id, sent_at);

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -15,6 +15,7 @@ const exportRoutes = require('./routes/export');
 const apiKeysRoutes = require('./routes/apiKeys');
 const emailRoutes = require('./routes/email');
 const communityRoutes = require('./routes/community');
+const notificationRoutes = require('./routes/notifications');
 const swaggerSpec = require('./swagger');
 const swaggerUi = require('swagger-ui-express');
 const cookieParser = require('cookie-parser');
@@ -97,6 +98,7 @@ app.use('/api/export', exportRoutes);
 app.use('/api/keys', apiKeysRoutes);
 app.use('/api/email', emailRoutes);
 app.use('/api/community', communityRoutes);
+app.use('/api/notifications', notificationRoutes);
 app.use('/health', healthRoutes);
 
 // Metrics endpoint for monitoring

--- a/backend/src/notifications/push.js
+++ b/backend/src/notifications/push.js
@@ -1,0 +1,286 @@
+/**
+ * Push Notification Service
+ *
+ * Handles sending web push notifications to subscribed clients.
+ * Supports pattern alerts, prediction shifts, and daily summaries.
+ */
+
+const webpush = require('web-push');
+const db = require('../db');
+const config = require('../config');
+
+// Configure VAPID details if keys are available
+if (process.env.VAPID_PUBLIC_KEY && process.env.VAPID_PRIVATE_KEY) {
+  webpush.setVapidDetails(
+    process.env.VAPID_SUBJECT || 'mailto:alerts@whatshappening.app',
+    process.env.VAPID_PUBLIC_KEY,
+    process.env.VAPID_PRIVATE_KEY
+  );
+  console.log('Web push configured with VAPID keys');
+} else {
+  console.warn('VAPID keys not configured — push notifications disabled');
+}
+
+/**
+ * Check if push is configured
+ */
+function isConfigured() {
+  return !!(process.env.VAPID_PUBLIC_KEY && process.env.VAPID_PRIVATE_KEY);
+}
+
+// --- Subscription Management ---
+
+async function saveSubscription(endpoint, keys, userAgent = null) {
+  const result = await db.query(
+    `INSERT INTO push_subscriptions (endpoint, keys_p256dh, keys_auth, user_agent)
+     VALUES ($1, $2, $3, $4)
+     ON CONFLICT (endpoint) DO UPDATE SET
+       keys_p256dh = EXCLUDED.keys_p256dh,
+       keys_auth = EXCLUDED.keys_auth,
+       user_agent = EXCLUDED.user_agent
+     RETURNING id, preferences, created_at`,
+    [endpoint, keys.p256dh, keys.auth, userAgent]
+  );
+  return result.rows[0];
+}
+
+async function removeSubscription(endpoint) {
+  const result = await db.query(
+    'DELETE FROM push_subscriptions WHERE endpoint = $1 RETURNING id',
+    [endpoint]
+  );
+  return result.rowCount > 0;
+}
+
+async function updatePreferences(endpoint, preferences) {
+  const result = await db.query(
+    `UPDATE push_subscriptions
+     SET preferences = preferences || $2::jsonb
+     WHERE endpoint = $1
+     RETURNING id, preferences`,
+    [endpoint, JSON.stringify(preferences)]
+  );
+  return result.rows[0] || null;
+}
+
+async function getSubscriptionStatus(endpoint) {
+  const result = await db.query(
+    'SELECT id, preferences, created_at, last_used FROM push_subscriptions WHERE endpoint = $1',
+    [endpoint]
+  );
+  return result.rows[0] || null;
+}
+
+async function getActiveSubscriptions(notificationType) {
+  const result = await db.query(
+    `SELECT id, endpoint, keys_p256dh, keys_auth, preferences
+     FROM push_subscriptions
+     WHERE preferences->>$1 = 'true'`,
+    [notificationType]
+  );
+  return result.rows;
+}
+
+// --- Sending ---
+
+async function sendNotification(subscription, payload, type) {
+  const pushSubscription = {
+    endpoint: subscription.endpoint,
+    keys: {
+      p256dh: subscription.keys_p256dh,
+      auth: subscription.keys_auth,
+    },
+  };
+
+  try {
+    await webpush.sendNotification(pushSubscription, JSON.stringify(payload));
+
+    // Update last_used
+    await db.query(
+      'UPDATE push_subscriptions SET last_used = NOW() WHERE endpoint = $1',
+      [subscription.endpoint]
+    );
+
+    // Log successful send
+    await db.query(
+      `INSERT INTO notification_log (subscription_id, notification_type, payload, success)
+       VALUES ($1, $2, $3, true)`,
+      [subscription.id, type, JSON.stringify(payload)]
+    );
+
+    return true;
+  } catch (error) {
+    // 410 Gone = subscription expired, remove it
+    if (error.statusCode === 410 || error.statusCode === 404) {
+      await removeSubscription(subscription.endpoint);
+    }
+
+    // Log failure
+    try {
+      await db.query(
+        `INSERT INTO notification_log (subscription_id, notification_type, payload, success, error_message)
+         VALUES ($1, $2, $3, false, $4)`,
+        [subscription.id, type, JSON.stringify(payload), error.message]
+      );
+    } catch (_) { /* logging failure is non-critical */ }
+
+    return false;
+  }
+}
+
+// --- Rate Limiting & Quiet Hours ---
+
+async function getTodayNotificationCount(subscriptionId) {
+  const result = await db.query(
+    `SELECT COUNT(*) as count FROM notification_log
+     WHERE subscription_id = $1
+       AND sent_at > CURRENT_DATE
+       AND success = true`,
+    [subscriptionId]
+  );
+  return parseInt(result.rows[0].count, 10);
+}
+
+function isQuietHours(preferences) {
+  const now = new Date();
+  const hour = now.getUTCHours(); // Use UTC; clients can set their preferred quiet hours
+  const quiet = preferences.quiet_hours || { start: 23, end: 7 };
+  if (quiet.start > quiet.end) {
+    // Wraps midnight: e.g. 23-7
+    return hour >= quiet.start || hour < quiet.end;
+  }
+  return hour >= quiet.start && hour < quiet.end;
+}
+
+async function shouldSendNotification(subscription, type) {
+  const prefs = subscription.preferences || {};
+
+  // Check if type is enabled
+  if (prefs[type] === false) return false;
+
+  // Check quiet hours (skip for urgent alerts)
+  if (type !== 'urgent' && isQuietHours(prefs)) return false;
+
+  // Check daily rate limit (max 5/day per subscription)
+  const todayCount = await getTodayNotificationCount(subscription.id);
+  if (todayCount >= 5) return false;
+
+  return true;
+}
+
+// --- Notification Types ---
+
+async function sendPatternAlert(pattern) {
+  if (!isConfigured()) return { sent: 0, skipped: 0 };
+
+  const subscriptions = await getActiveSubscriptions('pattern_alerts');
+  const payload = {
+    title: '🔮 Pattern Match Detected',
+    body: `${pattern.avgSimilarity ? Math.round(pattern.avgSimilarity * 100) : pattern.similarity}% match with historical patterns`,
+    icon: '/images/icon-192.png',
+    badge: '/images/badge-72.png',
+    tag: 'pattern-alert',
+    data: {
+      url: '/?highlight=pattern',
+      type: 'pattern_alert',
+      matchCount: pattern.matchCount,
+    },
+  };
+
+  let sent = 0;
+  let skipped = 0;
+  await Promise.allSettled(
+    subscriptions.map(async (sub) => {
+      if (await shouldSendNotification(sub, 'pattern_alerts')) {
+        const ok = await sendNotification(sub, payload, 'pattern_alert');
+        if (ok) sent++; else skipped++;
+      } else {
+        skipped++;
+      }
+    })
+  );
+
+  return { sent, skipped };
+}
+
+async function sendPredictionShiftAlert(outcome, oldProbability, newProbability) {
+  if (!isConfigured()) return { sent: 0, skipped: 0 };
+
+  const shift = Math.round((newProbability - oldProbability) * 100);
+  const direction = shift > 0 ? '📈' : '📉';
+
+  const subscriptions = await getActiveSubscriptions('prediction_shifts');
+  const payload = {
+    title: `${direction} Prediction Shift: ${outcome}`,
+    body: `Changed by ${Math.abs(shift)}% (now ${Math.round(newProbability * 100)}%)`,
+    icon: '/images/icon-192.png',
+    badge: '/images/badge-72.png',
+    tag: `prediction-shift-${outcome}`,
+    data: {
+      url: '/?tab=predictions',
+      type: 'prediction_shift',
+      outcome,
+      oldProbability,
+      newProbability,
+    },
+  };
+
+  let sent = 0;
+  let skipped = 0;
+  await Promise.allSettled(
+    subscriptions.map(async (sub) => {
+      if (await shouldSendNotification(sub, 'prediction_shifts')) {
+        const ok = await sendNotification(sub, payload, 'prediction_shift');
+        if (ok) sent++; else skipped++;
+      } else {
+        skipped++;
+      }
+    })
+  );
+
+  return { sent, skipped };
+}
+
+async function sendDailySummary(summary) {
+  if (!isConfigured()) return { sent: 0, skipped: 0 };
+
+  const subscriptions = await getActiveSubscriptions('daily_summary');
+  const payload = {
+    title: "📊 Today's Forecast",
+    body: `Tension: ${summary.overallTension} | Top risk: ${(summary.topRisks || [])[0] || 'None'}`,
+    icon: '/images/icon-192.png',
+    badge: '/images/badge-72.png',
+    tag: 'daily-summary',
+    data: {
+      url: '/',
+      type: 'daily_summary',
+    },
+  };
+
+  let sent = 0;
+  let skipped = 0;
+  await Promise.allSettled(
+    subscriptions.map(async (sub) => {
+      if (await shouldSendNotification(sub, 'daily_summary')) {
+        const ok = await sendNotification(sub, payload, 'daily_summary');
+        if (ok) sent++; else skipped++;
+      } else {
+        skipped++;
+      }
+    })
+  );
+
+  return { sent, skipped };
+}
+
+module.exports = {
+  isConfigured,
+  saveSubscription,
+  removeSubscription,
+  updatePreferences,
+  getSubscriptionStatus,
+  sendPatternAlert,
+  sendPredictionShiftAlert,
+  sendDailySummary,
+  getActiveSubscriptions,
+};

--- a/backend/src/routes/notifications.js
+++ b/backend/src/routes/notifications.js
@@ -1,0 +1,128 @@
+/**
+ * Push Notification Routes
+ *
+ * Subscription management and VAPID public key endpoint.
+ */
+
+const express = require('express');
+const router = express.Router();
+const push = require('../notifications/push');
+
+// GET /api/notifications/vapid-public-key
+// Returns the VAPID public key for client-side subscription
+router.get('/vapid-public-key', (req, res) => {
+  if (!push.isConfigured()) {
+    return res.status(503).json({ error: 'Push notifications not configured' });
+  }
+  res.json({ publicKey: process.env.VAPID_PUBLIC_KEY });
+});
+
+// POST /api/notifications/subscribe
+router.post('/subscribe', async (req, res) => {
+  try {
+    if (!push.isConfigured()) {
+      return res.status(503).json({ error: 'Push notifications not configured' });
+    }
+
+    const { endpoint, keys } = req.body;
+    if (!endpoint || !keys || !keys.p256dh || !keys.auth) {
+      return res.status(400).json({
+        error: 'Invalid subscription',
+        required: ['endpoint', 'keys.p256dh', 'keys.auth'],
+      });
+    }
+
+    const userAgent = req.headers['user-agent'] || null;
+    const subscription = await push.saveSubscription(endpoint, keys, userAgent);
+
+    res.status(201).json({
+      message: 'Subscribed successfully',
+      id: subscription.id,
+      preferences: subscription.preferences,
+    });
+  } catch (error) {
+    console.error('Subscribe error:', error);
+    res.status(500).json({ error: 'Failed to subscribe' });
+  }
+});
+
+// DELETE /api/notifications/unsubscribe
+router.delete('/unsubscribe', async (req, res) => {
+  try {
+    const { endpoint } = req.body;
+    if (!endpoint) {
+      return res.status(400).json({ error: 'endpoint is required' });
+    }
+
+    const removed = await push.removeSubscription(endpoint);
+    if (!removed) {
+      return res.status(404).json({ error: 'Subscription not found' });
+    }
+
+    res.json({ message: 'Unsubscribed successfully' });
+  } catch (error) {
+    console.error('Unsubscribe error:', error);
+    res.status(500).json({ error: 'Failed to unsubscribe' });
+  }
+});
+
+// PATCH /api/notifications/preferences
+router.patch('/preferences', async (req, res) => {
+  try {
+    const { endpoint, preferences } = req.body;
+    if (!endpoint || !preferences) {
+      return res.status(400).json({ error: 'endpoint and preferences are required' });
+    }
+
+    // Validate preference keys
+    const validKeys = ['pattern_alerts', 'prediction_shifts', 'daily_summary', 'quiet_hours'];
+    const invalidKeys = Object.keys(preferences).filter(k => !validKeys.includes(k));
+    if (invalidKeys.length > 0) {
+      return res.status(400).json({
+        error: 'Invalid preference keys',
+        invalidKeys,
+        validKeys,
+      });
+    }
+
+    const result = await push.updatePreferences(endpoint, preferences);
+    if (!result) {
+      return res.status(404).json({ error: 'Subscription not found' });
+    }
+
+    res.json({
+      message: 'Preferences updated',
+      preferences: result.preferences,
+    });
+  } catch (error) {
+    console.error('Update preferences error:', error);
+    res.status(500).json({ error: 'Failed to update preferences' });
+  }
+});
+
+// GET /api/notifications/status
+router.get('/status', async (req, res) => {
+  try {
+    const { endpoint } = req.query;
+    if (!endpoint) {
+      return res.status(400).json({ error: 'endpoint query parameter is required' });
+    }
+
+    const subscription = await push.getSubscriptionStatus(endpoint);
+    if (!subscription) {
+      return res.json({ subscribed: false });
+    }
+
+    res.json({
+      subscribed: true,
+      preferences: subscription.preferences,
+      createdAt: subscription.created_at,
+      lastUsed: subscription.last_used,
+    });
+  } catch (error) {
+    console.error('Status check error:', error);
+    res.status(500).json({ error: 'Failed to check status' });
+  }
+});
+
+module.exports = router;

--- a/backend/src/scheduler.js
+++ b/backend/src/scheduler.js
@@ -238,6 +238,48 @@ function startScheduler() {
     timezone: 'UTC'
   });
 
+  // Schedule push notification checks after correlation updates (every 3 hours)
+  cron.schedule('30 */3 * * *', async () => {
+    try {
+      const push = require('./notifications/push');
+      if (!push.isConfigured()) return;
+
+      // Check for pattern alerts
+      const patterns = await correlation.getPatternMatches();
+      if (patterns && patterns.matchCount > 0 && patterns.avgSimilarity > 0.80) {
+        const result = await push.sendPatternAlert(patterns);
+        logger.info(`Pattern alert: ${result.sent} sent, ${result.skipped} skipped`);
+      }
+    } catch (err) {
+      logger.error('Push notification check failed:', err.message);
+    }
+  }, {
+    scheduled: true,
+    timezone: 'UTC'
+  });
+
+  // Schedule daily push summary (9:00 AM UTC)
+  cron.schedule('0 9 * * *', async () => {
+    try {
+      const push = require('./notifications/push');
+      if (!push.isConfigured()) return;
+
+      // Get prediction summary for daily push
+      const apiRoutes = require('./routes/api');
+      const predictionEngine = require('./prediction');
+      const summary = await predictionEngine.getSummary();
+      if (summary) {
+        const result = await push.sendDailySummary(summary);
+        logger.info(`Daily push summary: ${result.sent} sent, ${result.skipped} skipped`);
+      }
+    } catch (err) {
+      logger.error('Daily push summary failed:', err.message);
+    }
+  }, {
+    scheduled: true,
+    timezone: 'UTC'
+  });
+
   // Schedule daily email digest (8:00 AM UTC)
   cron.schedule('0 8 * * *', async () => {
     logger.info('Running daily email digest');

--- a/backend/src/swagger.js
+++ b/backend/src/swagger.js
@@ -73,6 +73,10 @@ This API provides access to:
         name: 'Health',
         description: 'Service health and status checks',
       },
+      {
+        name: 'Notifications',
+        description: 'Push notification subscription management',
+      },
     ],
     paths: {
       '/api/current': {
@@ -575,6 +579,145 @@ This API provides access to:
                 'application/json': {
                   schema: {
                     $ref: '#/components/schemas/Error',
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      '/api/notifications/vapid-public-key': {
+        get: {
+          tags: ['Notifications'],
+          summary: 'Get VAPID public key',
+          description: 'Returns the VAPID public key needed for client-side push subscription.',
+          operationId: 'getVapidPublicKey',
+          responses: {
+            200: {
+              description: 'VAPID public key',
+              content: {
+                'application/json': {
+                  schema: {
+                    type: 'object',
+                    properties: { publicKey: { type: 'string' } },
+                  },
+                },
+              },
+            },
+            503: { description: 'Push notifications not configured' },
+          },
+        },
+      },
+      '/api/notifications/subscribe': {
+        post: {
+          tags: ['Notifications'],
+          summary: 'Subscribe to push notifications',
+          operationId: 'subscribe',
+          requestBody: {
+            required: true,
+            content: {
+              'application/json': {
+                schema: { $ref: '#/components/schemas/PushSubscriptionRequest' },
+              },
+            },
+          },
+          responses: {
+            201: {
+              description: 'Subscribed successfully',
+              content: {
+                'application/json': {
+                  schema: {
+                    type: 'object',
+                    properties: {
+                      message: { type: 'string' },
+                      id: { type: 'integer' },
+                      preferences: { $ref: '#/components/schemas/NotificationPreferences' },
+                    },
+                  },
+                },
+              },
+            },
+            400: { description: 'Invalid subscription data' },
+            503: { description: 'Push notifications not configured' },
+          },
+        },
+      },
+      '/api/notifications/unsubscribe': {
+        delete: {
+          tags: ['Notifications'],
+          summary: 'Unsubscribe from push notifications',
+          operationId: 'unsubscribe',
+          requestBody: {
+            required: true,
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  required: ['endpoint'],
+                  properties: { endpoint: { type: 'string' } },
+                },
+              },
+            },
+          },
+          responses: {
+            200: { description: 'Unsubscribed successfully' },
+            404: { description: 'Subscription not found' },
+          },
+        },
+      },
+      '/api/notifications/preferences': {
+        patch: {
+          tags: ['Notifications'],
+          summary: 'Update notification preferences',
+          operationId: 'updateNotificationPreferences',
+          requestBody: {
+            required: true,
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  required: ['endpoint', 'preferences'],
+                  properties: {
+                    endpoint: { type: 'string' },
+                    preferences: { $ref: '#/components/schemas/NotificationPreferences' },
+                  },
+                },
+              },
+            },
+          },
+          responses: {
+            200: { description: 'Preferences updated' },
+            400: { description: 'Invalid preference keys' },
+            404: { description: 'Subscription not found' },
+          },
+        },
+      },
+      '/api/notifications/status': {
+        get: {
+          tags: ['Notifications'],
+          summary: 'Get subscription status',
+          operationId: 'getNotificationStatus',
+          parameters: [
+            {
+              name: 'endpoint',
+              in: 'query',
+              required: true,
+              schema: { type: 'string' },
+            },
+          ],
+          responses: {
+            200: {
+              description: 'Subscription status',
+              content: {
+                'application/json': {
+                  schema: {
+                    type: 'object',
+                    properties: {
+                      subscribed: { type: 'boolean' },
+                      preferences: { $ref: '#/components/schemas/NotificationPreferences' },
+                      createdAt: { type: 'string', format: 'date-time' },
+                      lastUsed: { type: 'string', format: 'date-time', nullable: true },
+                    },
                   },
                 },
               },
@@ -1119,6 +1262,36 @@ This API provides access to:
           properties: {
             error: { type: 'string' },
             message: { type: 'string' },
+          },
+        },
+        PushSubscriptionRequest: {
+          type: 'object',
+          required: ['endpoint', 'keys'],
+          properties: {
+            endpoint: { type: 'string', description: 'Push subscription endpoint URL' },
+            keys: {
+              type: 'object',
+              required: ['p256dh', 'auth'],
+              properties: {
+                p256dh: { type: 'string' },
+                auth: { type: 'string' },
+              },
+            },
+          },
+        },
+        NotificationPreferences: {
+          type: 'object',
+          properties: {
+            pattern_alerts: { type: 'boolean', default: true },
+            prediction_shifts: { type: 'boolean', default: true },
+            daily_summary: { type: 'boolean', default: false },
+            quiet_hours: {
+              type: 'object',
+              properties: {
+                start: { type: 'integer', minimum: 0, maximum: 23, default: 23 },
+                end: { type: 'integer', minimum: 0, maximum: 23, default: 7 },
+              },
+            },
           },
         },
         ValidationError: {


### PR DESCRIPTION
## Summary

Implements the backend for push notifications (EPIC-005, Issue #76).

### What's included

**Push Service** (`backend/src/notifications/push.js`):
- VAPID/web-push configuration
- Subscription management (save, remove, update preferences)
- Three notification types: pattern alerts, prediction shifts, daily summary
- Rate limiting (5 notifications/day per subscription)
- Quiet hours support (configurable per subscriber)
- Auto-cleanup of expired subscriptions (410 Gone)

**API Routes** (`backend/src/routes/notifications.js`):
- `GET /api/notifications/vapid-public-key` — client key for subscription
- `POST /api/notifications/subscribe` — register push subscription
- `DELETE /api/notifications/unsubscribe` — remove subscription
- `PATCH /api/notifications/preferences` — update notification preferences
- `GET /api/notifications/status` — check subscription status

**Database** (migration 007):
- `push_subscriptions` table with JSONB preferences
- `notification_log` table for rate limiting and audit

**Scheduler Integration**:
- Pattern alert check every 3 hours (triggers on >80% similarity)
- Daily push summary at 9:00 AM UTC

**Documentation**:
- All notification endpoints added to Swagger/OpenAPI spec
- VAPID env vars added to .env.example

### Remaining (frontend tasks for FE/Mobile):
- Service worker push handler (Task 7)
- Frontend subscription UI (Task 8)
- These depend on EPIC-003 (PWA) which is already merged

### Testing
- VAPID keys need to be generated and configured (`npx web-push generate-vapid-keys`)
- Graceful degradation: if VAPID keys aren't set, push features return 503